### PR TITLE
Raise base, TH, pretty version upper bounds for ghc 7.2 rc1, add FlexibleInstance for ghc 7.2 rc1

### DIFF
--- a/haskell-src-meta.cabal
+++ b/haskell-src-meta.cabal
@@ -17,10 +17,10 @@ description:        The translation from haskell-src-exts abstract syntax
 extra-source-files: examples/*.hs README
 
 library
-  build-depends:   base >= 4.1 && < 4.4,
+  build-depends:   base >= 4.1 && < 4.5,
                    haskell-src-exts >= 1.6 && < 1.12,
-                   template-haskell >= 2.3 && < 2.6,
-                   pretty == 1.0.*,
+                   template-haskell >= 2.3 && < 2.7,
+                   pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.4,
                    th-lift == 0.5.*
   extensions:      CPP,

--- a/src/Language/Haskell/Meta/Syntax/Translate.hs
+++ b/src/Language/Haskell/Meta/Syntax/Translate.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, TemplateHaskell, TypeSynonymInstances #-}
+{-# LANGUAGE CPP, TemplateHaskell, TypeSynonymInstances, FlexibleInstances #-}
 
 {- |
   Module      :  Language.Haskell.Meta.Syntax.Translate


### PR DESCRIPTION
Built with ghc 7.2rc1, 7.0.4 and 6.12.3 on Gentoo Linux 3.0 amd64
