### PR TITLE
Add toTypeName to fix a bug in AST translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/dist/
+/cabal-dev/
+*.swp


### PR DESCRIPTION
This patch addresses a bug that was showing up when translating the result of parseHsType with toType.  The test case is this program:

```haskell
{-# LANGUAGE TemplateHaskell #-}

import Language.Haskell.Exts
import Language.Haskell.Meta

f :: $( let Right ty = parseHsType "()" in return (toType ty) )
f  = ()
```

Which gives a kind error on at least ghc 7.4 and 7.6.

The problem stems from how names get translated, namely special names like `()` and `[]`.  As ghc supports promoting values to the type level, translating the type `()` using `'()` causes a value name to be written out, instead of a type name.

This patch solves this problem by introducing another function to the `ToName` class, `toTypeName`.  With the addition of `toTypeName`, `()` can now be translated as `''()` in the context where it's a type name, and `'()` in the context where it's a value name.

I also added a .gitignore :)