### PR TITLE
Added "data instance" and "type instance" translations.

### DIFF
--- a/src/Language/Haskell/Meta/Parse/Careful.hs
+++ b/src/Language/Haskell/Meta/Parse/Careful.hs
@@ -24,16 +24,21 @@ When this danger arises, we use this \"careful\" module. It handles \"unresolved
 
 -}
 module Language.Haskell.Meta.Parse.Careful(
-  parsePat, 
-  parseExp, 
-  parseType, 
-  parseDecs
+  parsePat,
+  parseExp,
+  parseType,
+  parseDecs,
+  parsePatWithMode,
+  parseExpWithMode,
+  parseTypeWithMode,
+  parseDecsWithMode
  ) where
 
 import qualified Language.Haskell.Meta.Parse as Sloppy
 import qualified Language.Haskell.Meta.Syntax.Translate as Translate
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.Exts.Syntax as Hs
+import Language.Haskell.Exts.Parser (ParseMode)
 #if !(MIN_VERSION_template_haskell(2,7,0))
 import Data.Generics.Uniplate.Data
 #endif
@@ -56,6 +61,18 @@ parseType = doChecked Sloppy.parseHsType Translate.toType
 parseDecs :: String -> Either String [TH.Dec]
 parseDecs = doChecked Sloppy.parseHsDecls Translate.toDecs
 
+parsePatWithMode :: ParseMode -> String -> Either String TH.Pat
+parsePatWithMode m = doChecked (Sloppy.parseHsPatWithMode m) Translate.toPat
+
+parseExpWithMode :: ParseMode -> String -> Either String TH.Exp
+parseExpWithMode m = doChecked (Sloppy.parseHsExpWithMode m) Translate.toExp
+
+parseTypeWithMode :: ParseMode -> String -> Either String TH.Type
+parseTypeWithMode m = doChecked (Sloppy.parseHsTypeWithMode m) Translate.toType
+
+parseDecsWithMode :: ParseMode -> String -> Either String [TH.Dec]
+parseDecsWithMode m = doChecked (Sloppy.parseHsDeclsWithMode m) Translate.toDecs
+
 #if MIN_VERSION_template_haskell(2,7,0)
 amb = const False
 #else
@@ -71,3 +88,4 @@ amb syn = any isAmbExp (universeBi syn) || any isAmbPat (universeBi syn)
     isAmbPat (Hs.PInfixApp _ _ Hs.PInfixApp{}) = True
     isAmbPat _ = False
 #endif
+

--- a/src/Language/Haskell/Meta/Syntax/Translate.hs
+++ b/src/Language/Haskell/Meta/Syntax/Translate.hs
@@ -412,17 +412,6 @@ hsBangTypeToStrictType (Hs.BangedTy t)   = (IsStrict, toType t)
 hsBangTypeToStrictType (Hs.UnBangedTy t) = (NotStrict, toType t)
 
 
-hsTypeToNameAndTypes :: Hs.Type -> (Name, [Type])
-hsTypeToNameAndTypes = getTypes [] . toType
- where
-  getTypes ts (AppT a b)      = getTypes (b : ts) a
-  getTypes ts (ForallT _ _ a) = getTypes ts a
-  getTypes ts (ConT con)      = (con, ts)
-  getTypes ts (VarT con)      = (con, ts)
-  getTypes ts (PromotedT con) = (con, ts)
-  getTypes _ a = nonsense "hsTypeToNameAndTypes" "Unexpected type" a
-
-
 instance ToDec Hs.Decl where
   toDec (Hs.TypeDecl _ n ns t)
     = TySynD (toName n) (fmap toTyVar ns) (toType t)
@@ -476,22 +465,6 @@ instance ToDec Hs.Decl where
   -- TODO: do something with context?
   toDec (Hs.DataFamDecl _ _ n ns k)
     = FamilyD DataFam (toName n) (fmap toTyVar ns) (fmap toKind k)
-
-  -- Had family declarations, but no instances.
-  toDec (Hs.TypeInsDecl _ t0 t1)
-    = let (n, ts) = hsTypeToNameAndTypes t0
-      in TySynInstD n ts (toType t1)
-
-  toDec (Hs.DataInsDecl _ Hs.DataType t qcds qns)
-    = let (n, ts) = hsTypeToNameAndTypes t
-      in DataInstD [] n ts
-        (fmap qualConDeclToCon qcds)
-        (fmap (toName . fst) qns)
-  toDec (Hs.DataInsDecl _ Hs.NewType t (q:_) qns)
-    = let (n, ts) = hsTypeToNameAndTypes t
-      in NewtypeInstD [] n ts
-        (qualConDeclToCon q)
-        (fmap (toName . fst) qns)
 
 #endif /* MIN_VERSION_template_haskell(2,4,0) */
 


### PR DESCRIPTION
"newtype instance" doesn't seem to be supported in haskell-src-exts, neither do class type family declarations, so they don't compile correctly even with these new type translations in "toDec".
