### PR TITLE
Added "WithMode" function variants.  Use "fmap" in place of "either".

### DIFF
--- a/src/Language/Haskell/Meta/Parse/Careful.hs
+++ b/src/Language/Haskell/Meta/Parse/Careful.hs
@@ -24,16 +24,21 @@ When this danger arises, we use this \"careful\" module. It handles \"unresolved
 
 -}
 module Language.Haskell.Meta.Parse.Careful(
-  parsePat, 
-  parseExp, 
-  parseType, 
-  parseDecs
+  parsePat,
+  parseExp,
+  parseType,
+  parseDecs,
+  parsePatWithMode,
+  parseExpWithMode,
+  parseTypeWithMode,
+  parseDecsWithMode
  ) where
 
 import qualified Language.Haskell.Meta.Parse as Sloppy
 import qualified Language.Haskell.Meta.Syntax.Translate as Translate
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.Exts.Syntax as Hs
+import Language.Haskell.Exts.Parser (ParseMode)
 #if !(MIN_VERSION_template_haskell(2,7,0))
 import Data.Generics.Uniplate.Data
 #endif
@@ -56,6 +61,18 @@ parseType = doChecked Sloppy.parseHsType Translate.toType
 parseDecs :: String -> Either String [TH.Dec]
 parseDecs = doChecked Sloppy.parseHsDecls Translate.toDecs
 
+parsePatWithMode :: ParseMode -> String -> Either String TH.Pat
+parsePatWithMode m = doChecked (Sloppy.parseHsPatWithMode m) Translate.toPat
+
+parseExpWithMode :: ParseMode -> String -> Either String TH.Exp
+parseExpWithMode m = doChecked (Sloppy.parseHsExpWithMode m) Translate.toExp
+
+parseTypeWithMode :: ParseMode -> String -> Either String TH.Type
+parseTypeWithMode m = doChecked (Sloppy.parseHsTypeWithMode m) Translate.toType
+
+parseDecsWithMode :: ParseMode -> String -> Either String [TH.Dec]
+parseDecsWithMode m = doChecked (Sloppy.parseHsDeclsWithMode m) Translate.toDecs
+
 #if MIN_VERSION_template_haskell(2,7,0)
 amb = const False
 #else
@@ -71,3 +88,4 @@ amb syn = any isAmbExp (universeBi syn) || any isAmbPat (universeBi syn)
     isAmbPat (Hs.PInfixApp _ _ Hs.PInfixApp{}) = True
     isAmbPat _ = False
 #endif
+


### PR DESCRIPTION
Deprecation messages in Language.Haskell.Meta.Parse said not to use "myDefaultParseMode" or "myDefaultExtensions", and while they were still exported, there was no simple way to not use them by providing your own variants to the parse functions.  Instead, replicating chunks of the library was required.  I also simplified a lot of the code while I was at it.

It took me a few attempts to get this change set separated out from my other change set (hence the repeated reversions), but I've got it sorted now.  The two are entirely independent (though both directly related to my needs - one allows me to specify "TypeFamilies", the other parses type family declarations.
