### PR TITLE
Don't supply base fixities when UInfixE is available.

### DIFF
--- a/src/Language/Haskell/Meta/Parse.hs
+++ b/src/Language/Haskell/Meta/Parse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {- |
   Module      :  Language.Haskell.Meta.Parse
   Copyright   :  (c) Matt Morrow 2008
@@ -61,7 +62,11 @@ myDefaultParseMode = ParseMode
   ,extensions = map EnableExtension myDefaultExtensions
   ,ignoreLinePragmas = False
   ,ignoreLanguagePragmas = False
+#if MIN_VERSION_template_haskell(2,7,0)
+  ,fixities = Nothing}
+#else
   ,fixities = Just baseFixities}
+#endif
 
 myDefaultExtensions :: [KnownExtension]
 myDefaultExtensions = [PostfixOperators


### PR DESCRIPTION
As of template-haskell 2.7.0, template haskell has a UInfixE/UInfixP
constructor. By not supplying those fixities to haskell-src-exts,
you get an AST which uses those unresolved fixities. This makes parseExp
succeed more often, and means you get the "right" result if you decided
to use  parseExp "1+1*2", in a module that had + and \* defined with
the opposite fixities they have in base.
