### PR TITLE
toName: generate unqualified Name for tuple con

### DIFF
--- a/src/Language/Haskell/Meta/Syntax/Translate.hs
+++ b/src/Language/Haskell/Meta/Syntax/Translate.hs
@@ -117,9 +117,7 @@ instance ToName Hs.SpecialCon where
   toName Hs.FunCon  = ''(->)
   toName (Hs.TupleCon _ n)
     | n<2 = '()
-    | otherwise =
-      let x = maybe [] (++".") (nameModule '(,))
-      in mkName . concat $ x : ["(",replicate (n-1) ',',")"]
+    | otherwise = mkName $ "(" ++ replicate (n-1) ',' ++ ")"
   toName Hs.Cons    = '(:)
 
 


### PR DESCRIPTION
Generating a qualified name gives an error, as demonstrated by the following program:

```
{-# LANGUAGE TemplateHaskell #-}
import Language.Haskell.Meta
import Control.Applicative

main :: IO ()
main = do
  (a,b) <- $(let Right e = parseExp "liftA2 (,) getLine getLine" in return e)
  return ()
```

Before this patch, the following error was generated:

```
test.hs:7:14:
    Not in scope: data constructor `GHC.Tuple.(,)'
    In the result of the splice:
      $(let Right e = parseExp "liftA2 (,) getLine getLine" in return e)
    To see what the splice expanded to, use -ddump-splices
    In a stmt of a 'do' block:
      (a, b) <- $(let Right e = parseExp "liftA2 (,) getLine getLine"
                  in return e)
    In the expression:
      do { (a, b) <- $(let ... in return e);
           return () }
```

There is no way to redefine `(,)` in haskell as far as I know, so just using it unqualified should be safe. 
