### PR TITLE
update the th-orphans dependency

### DIFF
--- a/haskell-src-meta.cabal
+++ b/haskell-src-meta.cabal
@@ -22,7 +22,7 @@ library
                    haskell-src-exts == 1.16.*,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.7,
-                   th-orphans >= 0.9.1 && < 0.13
+                   th-orphans >= 0.13 && < 0.14
 
   Build-depends: template-haskell >= 2.7 && < 2.11
 


### PR DESCRIPTION
Was getting this error when compiling my project:

```
[1 of 1] Compiling Language.Haskell.TH.Instances ( src/Language/Haskell/TH/Instances.hs, dist/dist-sandbox-e46b1f0e/build/Language/Haskell/TH/Instances.o )

src/Language/Haskell/TH/Instances.hs:142:10:
    Duplicate instance declarations:
      instance Lift Natural
        -- Defined at src/Language/Haskell/TH/Instances.hs:142:10
      instance Lift Natural -- Defined in ‘Numeric.Natural’
cabal: Error: some packages failed to install:
haskell-src-meta-0.6.0.11 depends on th-orphans-0.12.2 which failed to
install.
```

upgraded the th-orphans dependency to 0.13 and the error is gone

have a strong feeling the error was resolved by this commit: https://github.com/mgsloan/th-orphans/commit/9372ff773d1f6c92397ba251fc92aae755bb7e77

