### PR TITLE
Update to compile with haskell-src-exts == 1.17.*

### DIFF
--- a/haskell-src-meta.cabal
+++ b/haskell-src-meta.cabal
@@ -19,7 +19,7 @@ extra-source-files: ChangeLog README examples/*.hs
 
 library
   build-depends:   base >= 4.5 && < 4.9,
-                   haskell-src-exts == 1.16.*,
+                   haskell-src-exts == 1.17.*,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.7,
                    th-orphans >= 0.9.1 && < 0.14

--- a/src/Language/Haskell/Meta/Parse.hs
+++ b/src/Language/Haskell/Meta/Parse.hs
@@ -62,7 +62,8 @@ myDefaultParseMode = ParseMode
   ,extensions = map EnableExtension myDefaultExtensions
   ,ignoreLinePragmas = False
   ,ignoreLanguagePragmas = False
-  ,fixities = Nothing}
+  ,fixities = Nothing
+  ,ignoreFunctionArity = False}
 
 myDefaultExtensions :: [KnownExtension]
 myDefaultExtensions = [PostfixOperators


### PR DESCRIPTION
This is pretty much the minimum amount of effort required to get it to compile with the new haskell-src-exts. 