### PR TITLE
Bump base and template-haskell to versions shipped with ghc-7.6

### DIFF
--- a/haskell-src-meta.cabal
+++ b/haskell-src-meta.cabal
@@ -17,11 +17,11 @@ description:        The translation from haskell-src-exts abstract syntax
 extra-source-files: ChangeLog README.md examples/*.hs
 
 library
-  build-depends:   base >= 4.5 && < 4.11,
+  build-depends:   base >= 4.6 && < 4.11,
                    haskell-src-exts >= 1.17 && < 1.20,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.8,
-                   template-haskell >= 2.7 && < 2.13,
+                   template-haskell >= 2.8 && < 2.13,
                    th-orphans >= 0.9.1 && < 0.14
 
   if impl(ghc < 7.8)


### PR DESCRIPTION
This is intended as a fix for issue #62.  Support for ghc-7.4.2 was dropped when support for haskell-src-exts-1.18 was added.  The versions of base and template-haskell can be verified here: https://downloads.haskell.org/~ghc/7.6.1/docs/html/users_guide/release-7-6-1.html