### PR TITLE
Support haskell-src-exts 1.20.x

### DIFF
--- a/haskell-src-meta.cabal
+++ b/haskell-src-meta.cabal
@@ -18,7 +18,7 @@ extra-source-files: ChangeLog README.md examples/*.hs
 
 library
   build-depends:   base >= 4.6 && < 4.11,
-                   haskell-src-exts >= 1.17 && < 1.20,
+                   haskell-src-exts >= 1.17 && < 1.21,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.8,
                    template-haskell >= 2.8 && < 2.13,
@@ -41,7 +41,7 @@ test-suite unit
   build-depends:
     HUnit                >= 1.2  && < 1.7,
     base                 >= 4.5  && < 4.11,
-    haskell-src-exts     >= 1.17 && < 1.20,
+    haskell-src-exts     >= 1.17 && < 1.21,
     haskell-src-meta,
     pretty               >= 1.0  && < 1.2,
     template-haskell     >= 2.7  && < 2.13,


### PR DESCRIPTION
This adds support for `haskell-src-exts >= 1.20 && < 1.21`, primarily adding support for deriving strategies. This should allow many of the packages dropped from Stackage in fpco/stackage#3140 to be reenabled once a new version of `haskell-src-meta` is released.

Fixes #70.