### PR TITLE
bump version bounds for ghc 8.6.1

### DIFF
--- a/haskell-src-meta.cabal
+++ b/haskell-src-meta.cabal
@@ -1,5 +1,5 @@
 name:               haskell-src-meta
-version:            0.8.0.4
+version:            0.8.0.5
 cabal-version:      >= 1.8
 build-type:         Simple
 license:            BSD3
@@ -9,7 +9,7 @@ author:             Matt Morrow
 copyright:          (c) Matt Morrow
 maintainer:         Ben Millwood <haskell@benmachine.co.uk>
 bug-reports:        https://github.com/bmillwood/haskell-src-meta/issues
-tested-with:        GHC == 7.6.3, GHC == 7.8.3, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.1
+tested-with:        GHC == 7.6.3, GHC == 7.8.3, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.1, GHC == 8.6.1
 synopsis:           Parse source to template-haskell abstract syntax.
 description:        The translation from haskell-src-exts abstract syntax
                     to template-haskell abstract syntax isn't 100% complete yet.
@@ -17,11 +17,11 @@ description:        The translation from haskell-src-exts abstract syntax
 extra-source-files: ChangeLog README.md examples/*.hs
 
 library
-  build-depends:   base >= 4.6 && < 4.12,
+  build-depends:   base >= 4.6 && < 5,
                    haskell-src-exts >= 1.18 && < 1.21,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.8,
-                   template-haskell >= 2.8 && < 2.14,
+                   template-haskell >= 2.8 && < 2.15,
                    th-orphans >= 0.9.1 && < 0.14
 
   if impl(ghc < 7.8)
@@ -40,11 +40,11 @@ test-suite unit
 
   build-depends:
     HUnit                >= 1.2  && < 1.7,
-    base                 >= 4.5  && < 4.12,
+    base                 >= 4.5  && < 5,
     haskell-src-exts     >= 1.17 && < 1.21,
     haskell-src-meta,
     pretty               >= 1.0  && < 1.2,
-    template-haskell     >= 2.7  && < 2.14,
+    template-haskell     >= 2.7  && < 2.15,
     test-framework       >= 0.8  && < 0.9,
     test-framework-hunit >= 0.3  && < 0.4
 


### PR DESCRIPTION
Seems to `cabal new-build` and `cabal new-test` just fine with the bumped versions